### PR TITLE
Added missing import-statement in SchemaGenerator

### DIFF
--- a/jaxb-ri/jxc/src/main/java/com/sun/tools/jxc/SchemaGenerator.java
+++ b/jaxb-ri/jxc/src/main/java/com/sun/tools/jxc/SchemaGenerator.java
@@ -46,6 +46,7 @@ import com.sun.xml.bind.util.Which;
 
 import javax.lang.model.SourceVersion;
 import javax.tools.DiagnosticCollector;
+import javax.tools.Diagnostic;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.OptionChecker;


### PR DESCRIPTION
Hi

There was a missing import statement in SchemaGenerator so I added it (and it can now be built with maven).