### PR TITLE
JAXB-687 and JAXB-1124

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BIGlobalBinding.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BIGlobalBinding.java
@@ -558,12 +558,10 @@ public final class BIGlobalBinding extends AbstractDeclarationImpl {
             this.fixedAttributeAsConstantProperty == b.fixedAttributeAsConstantProperty &&
             this.generateEnumMemberName == b.generateEnumMemberName &&
             this.codeGenerationStrategy == b.codeGenerationStrategy &&
-            this.serializable == b.serializable &&
             this.superClass == b.superClass &&
             this.superInterface == b.superInterface &&
             this.generateElementClass == b.generateElementClass &&
             this.generateMixedExtensions == b.generateMixedExtensions &&
-            this.generateElementProperty == b.generateElementProperty &&
             this.choiceContentProperty == b.choiceContentProperty &&
             this.optionalProperty == b.optionalProperty &&
             this.defaultEnumMemberSizeCap == b.defaultEnumMemberSizeCap &&
@@ -571,7 +569,9 @@ public final class BIGlobalBinding extends AbstractDeclarationImpl {
 
         if (!equal) return false;
 
-        return isEqual(this.nameConverter, b.nameConverter) &&
+        return isEqual(this.serializable, b.serializable) &&
+               isEqual(this.generateElementProperty, b.generateElementProperty) &&
+               isEqual(this.nameConverter, b.nameConverter) &&
                isEqual(this.noMarshaller, b.noMarshaller) &&
                isEqual(this.noUnmarshaller, b.noUnmarshaller) &&
                isEqual(this.noValidator, b.noValidator) &&

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BISerializable.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BISerializable.java
@@ -56,4 +56,19 @@ public final class BISerializable {
     /** serial version UID, or null to avoid generating the serialVersionUID field. */
     @XmlAttribute
     public Long uid;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BISerializable that = (BISerializable) o;
+
+        return uid != null ? uid.equals(that.uid) : that.uid == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return uid != null ? uid.hashCode() : 0;
+    }
 }


### PR DESCRIPTION
This fixes [JAXB-687](https://webcache.googleusercontent.com/search?q=cache:Foy79conrIMJ:https://java.net/jira/browse/JAXB-687) and [JAXB-1124](https://webcache.googleusercontent.com/search?q=cache:aTtvkBiRIOoJ:https://java.net/jira/browse/JAXB-1124).

Both `serializable` and `generateElementProperty` are objects. Comparing them with `equals` works as expected